### PR TITLE
Bugfixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.3.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.1
+- fixed hashtag symbol outputting quote symbol
+- fixed hyperspeed printing failure in test_cupp.py
+- added support for windows clearing terminal on hyperspeed print
+
 ## 3.2.0-alpha
 
  - ran 2to3 on cupp.py to make it Python3 compatible

--- a/cupp.cfg
+++ b/cupp.cfg
@@ -30,7 +30,7 @@ z=2
 # separated by comma
 
 [specialchars]
-chars=!,@,'#',$,%%,&,*
+chars=!,@,#,$,%%,&,*
 
 
 # [ Random years ] take it as much as you need!

--- a/cupp.py
+++ b/cupp.py
@@ -142,7 +142,10 @@ def print_to_file(filename, unique_list_finished):
                 for line in data:
                     print("\033[1;32m[" + filename + "] \033[1;33m" + line)
                     time.sleep(0000.1)
-                    os.system("clear")
+                    if os.name == "nt":
+                        os.system("cls")
+                    else:
+                        os.system("clear")
         except Exception as e:
             print("[ERROR]: " + str(e))
     else:

--- a/cupp.py
+++ b/cupp.py
@@ -44,7 +44,7 @@ import time
 
 __author__ = "Mebus"
 __license__ = "GPL"
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 CONFIG = {}
 

--- a/test_cupp.py
+++ b/test_cupp.py
@@ -132,6 +132,7 @@ class TestCupp(unittest.TestCase):
             "Y",  # Special chars
             "N",  # Random
             "N",  # Leet mode
+            "Y",  # Hyperspeed Print
         ]
 
         test_ok = False


### PR DESCRIPTION
Main thing is I think your build will now be marked as passing with this update. Tests were failing on hyperspeed print. I've tested on on windows and mac, it appears to be working.

The # symbol was printing with quotes around it. Since it is a config file you don't need the quotes. Some parsers will incorrectly show it is a comment, but it functions correctly now and only outputs the # symbol with no quotes.  

Last thing is windows doesn't support `os.system('clear')`. I added and tested the corresponding windows clear command.

Great program!  Really appreciate your work in getting it this far. Hope to add a feature or two someday soon.  