### PR TITLE
added support to specify output path of wordlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,30 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.2.0-alpha
 
- - ran 2to3 on cupp.py to make it Python3 compatible
+- ran 2to3 on cupp.py to make it Python3 compatible
 
 ## 3.1.0-alpha
- - added Python3 port
- - Bugfixes
+
+- added Python3 port
+- Bugfixes
 
 ## 3.0.0
- - added word length shaping function
- - added wordlists downloader function
- - added alectodb parser
- - fixed thresholds for word concatenations
- - fixed sorting in final parsing
- - fixed some user input validations
- - ascii cow now looks nicer :)
+
+- added word length shaping function
+- added wordlists downloader function
+- added alectodb parser
+- fixed thresholds for word concatenations
+- fixed sorting in final parsing
+- fixed some user input validations
+- ascii cow now looks nicer :)
 
 ## 2.0.0
- - added l33t mode
- - added char mode
- - ability to make pwnsauce with other wordlists or wyd.pl outputs
- - cupp.cfg makes cupp.py easier to configure 
 
+- added l33t mode
+- added char mode
+- ability to make pwnsauce with other wordlists or wyd.pl outputs
+- cupp.cfg makes cupp.py easier to configure
 
 ## 1.0.0
-- Initial release
 
+- Initial release

--- a/cupp.py
+++ b/cupp.py
@@ -307,7 +307,7 @@ def interactive(**kwargs):
 
     profile = {"output": os.path.dirname(os.path.realpath(__file__)) + os.sep }
 
-    if "output" and kwargs:
+    if "output" in kwargs:
         if not os.path.isdir(kwargs["output"]):
             print("\033[1;31m[-] Error Invalid Path, ensure path exists or check spelling.\033[1;0m")
             exit(1)

--- a/cupp.py
+++ b/cupp.py
@@ -301,16 +301,25 @@ def improve_dictionary(file_to_open):
     fajl.close()
 
 
-def interactive():
+def interactive(**kwargs):
     """Implementation of the -i switch. Interactively question the user and
     create a password dictionary file based on the answer."""
+
+    profile = {"output": os.path.dirname(os.path.realpath(__file__)) + os.sep }
+
+    if "output" and kwargs:
+        if not os.path.isdir(kwargs["output"]):
+            print("\033[1;31m[-] Error Invalid Path, ensure path exists or check spelling.\033[1;0m")
+            exit(1)
+
+        profile["output"] = kwargs["output"]
+        
 
     print("\r\n[+] Insert the information about the victim to make a dictionary")
     print("[+] If you don't know all the info, just hit enter when asked! ;)\r\n")
 
     # We need some information first!
 
-    profile = {}
 
     name = input("> First Name: ").lower()
     while len(name) == 0 or name == " " or name == "  " or name == "   ":
@@ -705,7 +714,7 @@ def generate_wordlist_from_profile(profile):
         if len(x) < CONFIG["global"]["wcto"] and len(x) > CONFIG["global"]["wcfrom"]
     ]
 
-    print_to_file(profile["name"] + ".txt", unique_list_finished)
+    print_to_file(profile["output"] + profile["name"] + ".txt", unique_list_finished)
 
 
 def download_http(url, targetfile):
@@ -1036,7 +1045,9 @@ def main():
     if args.version:
         version()
     elif args.interactive:
-        interactive()
+        # If Path is passed when running the program use parameter else call with no parameters
+        interactive(output=args.output) if args.output else interactive()
+    
     elif args.download_wordlist:
         download_wordlist()
     elif args.alecto:
@@ -1065,6 +1076,14 @@ def get_parser():
         metavar="FILENAME",
         help="Use this option to improve existing dictionary,"
         " or WyD.pl output to make some pwnsauce",
+    )
+    parser.add_argument(
+        "-o",
+        dest="output",
+        metavar="PATH",
+        type=str,
+        required=False,
+        help="Sepcify path where wordlist should be stored cupp -i -o ./PATH/"
     )
     group.add_argument(
         "-l",

--- a/test_cupp.py
+++ b/test_cupp.py
@@ -61,6 +61,7 @@ class TestCupp(unittest.TestCase):
             "randnum": "y",
             "leetmode": "y",
             "spechars": [],
+            "output" : os.path.dirname(os.path.realpath(__file__)) + os.sep,
         }
         read_config("cupp.cfg")
         generate_wordlist_from_profile(profile)


### PR DESCRIPTION
### Reason For Pull Request

This pull request addresses the need for a more convenient and flexible directory structure for generated wordlists in pentest assessments and CTF write-ups. The proposed changes enable users to easily specify the desired location for storing the wordlist, offering several benefits:

- Seamless chaining of commands with output stored in different directories without requiring directory changes.
- Compatibility with repositories like blackarch, where cupp is installed in /usr/share/. This avoids permission issues when writing the wordlist to the file system.

### Changes Made

The following modifications have been made to enhance the functionality of the program:

- Updated the CHANGELOG.md file to adhere to proper markdown styling.
- Introduced a new -o flag to the program, allowing users to specify the output directory for the wordlist.
- Adjusted the test_cupp script to incorporate the newly added wordlist output directory feature.