### PR TITLE
Fixed invalid escape sequences in string literals

### DIFF
--- a/cupp.py
+++ b/cupp.py
@@ -158,12 +158,12 @@ def print_to_file(filename, unique_list_finished):
 def print_cow():
     print(" ___________ ")
     print(" \033[07m  cupp.py! \033[27m                # \033[07mC\033[27mommon")
-    print("      \                     # \033[07mU\033[27mser")
-    print("       \   \033[1;31m,__,\033[1;m             # \033[07mP\033[27masswords")
+    print("      \\                     # \033[07mU\033[27mser")
+    print("       \\   \033[1;31m,__,\033[1;m             # \033[07mP\033[27masswords")
     print(
-        "        \  \033[1;31m(\033[1;moo\033[1;31m)____\033[1;m         # \033[07mP\033[27mrofiler"
+        "        \\  \033[1;31m(\033[1;moo\033[1;31m)____\033[1;m         # \033[07mP\033[27mrofiler"
     )
-    print("           \033[1;31m(__)    )\ \033[1;m  ")
+    print("           \033[1;31m(__)    )\\ \033[1;m  ")
     print(
         "           \033[1;31m   ||--|| \033[1;m\033[05m*\033[25m\033[1;m      [ Muris Kurgas | j0rgan@remote-exploit.org ]"
     )


### PR DESCRIPTION
Fix invalid escape sequences in `cupp.py`

The script `cupp.py` contains several instances of invalid escape sequences, which are causing SyntaxWarnings to be raised. This PR addresses these issues by fixing the escape sequences.

The changes made are:

1. In line 161, the escape sequence `\ ` has been replaced with `\\`.
2. In line 162, the escape sequence `\ ` has been replaced with `\\`.
3. In line 164, the escape sequence `\ ` has been replaced with `\\`.
4. In line 166, the escape sequence `\ ` has been replaced with `\\`.

These changes should resolve the SyntaxWarnings and make the script more readable and maintainable.
