### PR TITLE
fix: use UTF-8 encoding for file I/O on Windows

### DIFF
--- a/cupp.py
+++ b/cupp.py
@@ -117,11 +117,11 @@ def komb(seq, start, special=""):
 
 
 def print_to_file(filename, unique_list_finished):
-    f = open(filename, "w")
+    f = open(filename, "w", encoding="utf-8")
     unique_list_finished.sort()
     f.write(os.linesep.join(unique_list_finished))
     f.close()
-    f = open(filename, "r")
+    f = open(filename, "r", encoding="utf-8")
     lines = 0
     for line in f:
         lines += 1
@@ -136,7 +136,7 @@ def print_to_file(filename, unique_list_finished):
     inspect = input("> Hyperspeed Print? (Y/n) : ").lower()
     if inspect == "y":
         try:
-            with open(filename, "r+") as wlist:
+            with open(filename, "r+", encoding="utf-8") as wlist:
                 data = wlist.readlines()
                 for line in data:
                     print("\033[1;32m[" + filename + "] \033[1;33m" + line)

--- a/test_cupp.py
+++ b/test_cupp.py
@@ -27,6 +27,7 @@
 #  See 'LICENSE' for more information.
 
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -63,7 +64,33 @@ class TestCupp(unittest.TestCase):
             "spechars": [],
         }
         read_config("cupp.cfg")
-        generate_wordlist_from_profile(profile)
+        old_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                os.chdir(temp_dir)
+                with patch("builtins.input", return_value="n"):
+                    generate_wordlist_from_profile(profile)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_print_to_file_writes_utf8_with_cp1252_default_encoding(self):
+        real_open = open
+
+        def default_cp1252_open(file, mode="r", *args, **kwargs):
+            if "b" not in mode and "encoding" not in kwargs:
+                kwargs["encoding"] = "cp1252"
+            return real_open(file, mode, *args, **kwargs)
+
+        words = ["владимир", "путин", "Крим"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "wordlist.txt")
+            with patch("builtins.open", side_effect=default_cp1252_open):
+                with patch("builtins.input", return_value="n"):
+                    print_to_file(filename, words)
+
+            with real_open(filename, "r", encoding="utf-8") as wordlist:
+                self.assertEqual(wordlist.read().splitlines(), sorted(words))
 
     def test_parser(self):
         """ downloads a file and checks if it exists """


### PR DESCRIPTION
## Summary
On Windows, reading and writing wordlist/config files used the platform default encoding (cp1252), so non-ASCII characters raised `UnicodeDecodeError`/`UnicodeEncodeError` or were corrupted.

## Changes
Open the affected file reads/writes with explicit `encoding="utf-8"` so behavior matches Linux/macOS regardless of the Windows locale.

## Testing
Added a test in `test_cupp.py` covering round-tripping non-ASCII content.

Fixes #48
